### PR TITLE
Add assert for matrix boundaries and error handling

### DIFF
--- a/ScanSky_cuda.cu
+++ b/ScanSky_cuda.cu
@@ -30,7 +30,7 @@ __global__ void update_copy(int rows, int columns, int *matrixResultDev, int *ma
   int col, row;
 	col = blockIdx.x*blockDim.x+threadIdx.x;
 	row = blockIdx.y*blockDim.y+threadIdx.y;
-	if(0 < row && row < rows && 0 < col && col < columns){
+	if(0 < row && row < rows - 1 && 0 < col && col < columns - 1){
 		if(matrixResultDev[row*(columns)+col]!=-1){
 			matrixResultCopyDev[row*(columns)+col]=matrixResultDev[row*(columns)+col];
 		}
@@ -44,7 +44,7 @@ __global__ void computation(int rows, int columns, int* matrixData, int *matrixR
 	col = blockIdx.x*blockDim.x+threadIdx.x;
 	row = blockIdx.y*blockDim.y+threadIdx.y;
 	// Inicialmente cojo mi indice
-	if (0 < row && row < rows && 0 < col && col < columns) {
+	if (0 < row && row < rows - 1 && 0 < col && col < columns - 1) {
 		int result=matrixResultCopy[row*columns+col];
 		if( result!= -1){
 			//Si es de mi mismo grupo, entonces actualizo


### PR DESCRIPTION
Added conditions at kernel to avoid threads to take in to account matrix boundaries, rows and columns at each edge. (Basic solution to #2)

Also added error logs which activates when ERROR constant is defined. `-D ERROR` when compiling.

Gets execution error at copy from device to host of flagCambioArray  (req 8814, 8815): 

`ErrCUDA cpy flagCambio: an illegal memory access was encountered`

Frontend request done while testing: 8812, 8814, 8815, 8827